### PR TITLE
support 4 channel images

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -27,8 +27,8 @@ def handle_request(payload):
             base64_image = base64_image.split(';base64,')[1]
         image_data = base64.b64decode(base64_image)
         image_file_like = BytesIO(image_data)
-    
-    image = Image.open(image_file_like)
+
+    image = Image.open(image_file_like).convert("RGB")
     return image
 
 
@@ -50,7 +50,7 @@ def run_reverse_image_search(ctx):
     k = ctx.params.get("num_results")
 
     query_image = handle_request(ctx.params)
-    
+
     if hasattr(model, "embed"):
         query_embedding = model.embed(query_image)
     else:
@@ -87,8 +87,8 @@ class OpenReverseImageSearchPanel(foo.Operator):
         ctx.trigger(
             "open_panel",
             params=dict(
-                name="ReverseImageSearchPanel", 
-                isActive=True, 
+                name="ReverseImageSearchPanel",
+                isActive=True,
                 layout="horizontal"
             ),
         )


### PR DESCRIPTION
When attempting to search on a 4 channel image, this plugin errors with the following message:
```
The size of tensor a (4) must match the size of tensor b (3) at non-singleton dimension 0
```

This PR ensures all images are converted to 3 channel RGB before embedding them.

![alpha](https://github.com/jacobmarks/reverse-image-search-plugin/assets/21222883/49324362-331d-40b7-a9f1-b5ddd89c307a)
